### PR TITLE
Fix service worker example script path

### DIFF
--- a/docs/sw.js
+++ b/docs/sw.js
@@ -13,7 +13,7 @@ self.addEventListener('fetch', event => {
       fetch(req)
         .then(resp => resp.text())
         .then(html => {
-          const injected = html.replace('</body>', '<script src="/examples.js"></script></body>');
+          const injected = html.replace('</body>', '<script src="examples.js"></script></body>');
           return new Response(injected, { headers: resp.headers });
         })
     );


### PR DESCRIPTION
## Summary
- fix relative script path in `sw.js`

## Testing
- `node scripts/relative-links.js` *(fails: modifies many files so we reverted)*

------
https://chatgpt.com/codex/tasks/task_e_685953631e98832baf5f58a4c1990cf8